### PR TITLE
Use the UID for SASL auth, not the username

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -56,7 +56,7 @@ func (conn *Conn) Auth(methods []Auth) error {
 		if err != nil {
 			return err
 		}
-		methods = []Auth{AuthExternal(u.Username), AuthCookieSha1(u.Username, u.HomeDir)}
+		methods = []Auth{AuthExternal(u.Uid), AuthCookieSha1(u.Username, u.HomeDir)}
 	}
 	in := bufio.NewReader(conn.transport)
 	err := conn.transport.SendNullByte()


### PR DESCRIPTION
Otherwise, Duplicacy is unable to connect to certain D-Bus implementations. In particular, dbus-broker will reject the connections.

Would appreciate if a new Duplicacy is built soon with these changes :sweat_smile: 